### PR TITLE
Raw to x updates

### DIFF
--- a/RawToStdView.sql
+++ b/RawToStdView.sql
@@ -3,7 +3,10 @@
  * SQL Dialect: DuckDB
  *
  */
-CREATE TABLE IF NOT EXISTS HOST
+
+/* TODO: Change first() to mode(), which returns the most frequent value */
+
+CREATE TABLE IF NOT EXISTS host
 AS
 SELECT
  -- Ignore host.id.hash for now as it is really only composed of the hostname.

--- a/rawtorolling.py
+++ b/rawtorolling.py
@@ -13,12 +13,11 @@ def daterange(start_date, end_date):
         yield start_date + timedelta(n)
 
 def process_range(cur_dataset, start_date, end_date):
-    jpy = JinjaSql()
     for single_date in daterange(start_date, end_date):
         daypk=single_date.strftime("%Y%m%d")
         con=ru.initdb()
         globs=ru.get_globs_for(cur_dataset,daypk)
-        ru.create_raw_views(con,globs,jpy)
+        ru.create_raw_views(con,globs,daypk)
         ru.run_sql_no_args(con,'./RawToStdView.sql')
         ru.write_parquet(con,cur_dataset,ru.get_db_objects(con,exclude=['tmp']),daypk)
         con.close()

--- a/rawtorolling.py
+++ b/rawtorolling.py
@@ -17,7 +17,8 @@ def process_range(cur_dataset, start_date, end_date):
         daypk=single_date.strftime("%Y%m%d")
         con=ru.initdb()
         globs=ru.get_globs_for(cur_dataset,daypk)
-        ru.create_raw_views(con,globs,daypk)
+        # No need to pass dayPK as the globs already include it.
+        ru.create_raw_views(con,globs)
         ru.run_sql_no_args(con,'./RawToStdView.sql')
         ru.write_parquet(con,cur_dataset,ru.get_db_objects(con,exclude=['tmp']),daypk)
         con.close()

--- a/rawtostdview.py
+++ b/rawtostdview.py
@@ -1,8 +1,7 @@
 import argparse
+from datetime import datetime
 import logging
 import sys
-
-from jinjasql import JinjaSql
 
 import rawutil as ru
 
@@ -10,6 +9,8 @@ import rawutil as ru
 def main():
     parser = argparse.ArgumentParser( prog='rawtostdview.py', description='Convert raw Wintap data into standard form, no partitioning')
     parser.add_argument('-d','--dataset', help='Path to the dataset dir to process')
+    parser.add_argument('-s','--start', help='Start date (YYYYMMDD)')
+    parser.add_argument('-e','--end', help='End date (YYYYMMDD)')
     parser.add_argument('-l', '--log-level', default='INFO', help='Logging Level: INFO, WARN, ERROR, DEBUG')
     args = parser.parse_args()
     
@@ -20,10 +21,10 @@ def main():
         sys.exit(1)
 
     cur_dataset=args.dataset
-    jpy = JinjaSql()
+
     con = ru.initdb()
-    globs=ru.get_glob_paths_for_dataset(cur_dataset)
-    ru.create_raw_views(con,globs,jpy)
+    globs=ru.get_glob_paths_for_dataset(cur_dataset,subdir='rolling',include='raw_')
+    ru.create_raw_views(con,globs,args.start,args.end)
     ru.run_sql_no_args(con,'./RawToStdView.sql')
     ru.write_parquet(con,cur_dataset,ru.get_db_objects(con,exclude=['raw_','tmp']))
 


### PR DESCRIPTION
Implement new file naming conventions. Note, these changes will eventually be done in Wintap:

- Prefix all events types with raw_ when initially downloaded from S3. This will identify them as the original, tiny per host versions.
- Individual raw filenames pattern is: 
      [hostname]=[event type]-[timestamp].parquet
      The '=' causes a pattern match with Hive partitioning, so its getting replaced with '+'

Added start/end options to rawtostdview.py
Misc cleanup