### PR TITLE
couple of fixes

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,10 +1,11 @@
 [metadata]
 name = wintappy
 version = attr: wintappy.VERSION
-author = "LLNL"
-author_email = "grantj@llnl.gov"
-description = "Python utilities for working with Wintap data"
-license = "MIT License"
+author = LLNL
+author_email = grantj@llnl.gov
+description = Python utilities for working with Wintap data
+license = MIT License
+url = https://github.com/LLNL/Wintap-PyUtil
 
 [options]
 packages = find:

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,8 +16,7 @@ exclude =
     scripts*
 
 [options.package_data]
-datautils = 
-    *.sql
+wintappy.datautils = *.sql
 
 [options.entry_points]
 console_scripts = 

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ install_requires = [
     "networkx",
     "pandas",
     "pyarrow",
+    "python-dotenv",
     "toml",
     "tqdm"
 ]


### PR DESCRIPTION
## Description

In testing the nb one more time prior to release, found a couple of issues:
- missing dep in the setup file (it will be nice to automatically pull these in from the pipfile or elsewhere in the future!)
- incorrect path to package_data

## Testing Steps

1. setup test env

```bash
# create empty venv 
$ python -m venv test-dist
$ source test-dist/bin/activate
# create installable dist
$ python setup.py sdist
# install dist
$ pip install dist/wintappy-0.0.1.tar.gz
```

2. Run through QuackStart
     - point kernel to env setup in 1
     - run through all code blocks 