### PR TITLE
Add Table Check and Performance Improvements

### DIFF
--- a/wintappy/analytics/mitre_car/CAR-2014-04-003.sql
+++ b/wintappy/analytics/mitre_car/CAR-2014-04-003.sql
@@ -1,7 +1,7 @@
 -- Powershell Execution
 SELECT
-    child.pid_hash,
-    child.parent_pid_hash
+    child.pid_hash AS pid_hash,
+    COALESCE(child.first_seen, child.dayPK) as first_seen
 FROM process AS child,
     process AS parent
 WHERE

--- a/wintappy/analytics/mitre_car/CAR-2014-04-003.sql
+++ b/wintappy/analytics/mitre_car/CAR-2014-04-003.sql
@@ -1,7 +1,7 @@
 -- Powershell Execution
 SELECT
     child.pid_hash AS pid_hash,
-    COALESCE(child.first_seen, child.dayPK) as first_seen
+    COALESCE(child.first_seen, child.daypk) AS first_seen
 FROM process AS child,
     process AS parent
 WHERE

--- a/wintappy/analytics/mitre_car/CAR-2014-05-002.sql
+++ b/wintappy/analytics/mitre_car/CAR-2014-05-002.sql
@@ -1,7 +1,7 @@
 -- Services launching Cmd
 SELECT
     child.pid_hash AS pid_hash,
-    COALESCE(child.first_seen, child.dayPK) as first_seen
+    COALESCE(child.first_seen, child.daypk) AS first_seen
 FROM process AS child,
     process AS parent
 WHERE

--- a/wintappy/analytics/mitre_car/CAR-2014-05-002.sql
+++ b/wintappy/analytics/mitre_car/CAR-2014-05-002.sql
@@ -1,7 +1,7 @@
 -- Services launching Cmd
 SELECT
-    child.pid_hash,
-    parent.pid_hash
+    child.pid_hash AS pid_hash,
+    COALESCE(child.first_seen, child.dayPK) as first_seen
 FROM process AS child,
     process AS parent
 WHERE

--- a/wintappy/analytics/mitre_car/CAR-2014-11-004.sql
+++ b/wintappy/analytics/mitre_car/CAR-2014-11-004.sql
@@ -1,7 +1,7 @@
 -- Remote PowerShell Sessions
 SELECT
-    child.pid_hash as pid_hash,
-    COALESCE(child.first_seen, child.dayPK) as first_seen
+    child.pid_hash AS pid_hash,
+    COALESCE(child.first_seen, child.daypk) AS first_seen
 FROM process AS child,
     process AS parent
 WHERE

--- a/wintappy/analytics/mitre_car/CAR-2014-11-004.sql
+++ b/wintappy/analytics/mitre_car/CAR-2014-11-004.sql
@@ -1,7 +1,7 @@
 -- Remote PowerShell Sessions
 SELECT
-    child.pid_hash,
-    child.parent_pid_hash
+    child.pid_hash as pid_hash,
+    COALESCE(child.first_seen, child.dayPK) as first_seen
 FROM process AS child,
     process AS parent
 WHERE

--- a/wintappy/analytics/mitre_car/CAR-2014-11-008.sql
+++ b/wintappy/analytics/mitre_car/CAR-2014-11-008.sql
@@ -1,7 +1,7 @@
 -- Command Launched from WinLogon
 SELECT
-    child.pid_hash,
-    parent.pid_hash
+    child.pid_hash AS pid_hash,
+    COALESCE(child.first_seen, child.dayPK) as first_seen
 FROM process AS child,
     process AS parent
 WHERE

--- a/wintappy/analytics/mitre_car/CAR-2014-11-008.sql
+++ b/wintappy/analytics/mitre_car/CAR-2014-11-008.sql
@@ -1,7 +1,7 @@
 -- Command Launched from WinLogon
 SELECT
     child.pid_hash AS pid_hash,
-    COALESCE(child.first_seen, child.dayPK) as first_seen
+    COALESCE(child.first_seen, child.daypk) AS first_seen
 FROM process AS child,
     process AS parent
 WHERE

--- a/wintappy/analytics/mitre_car/CAR-2019-04-002.sql
+++ b/wintappy/analytics/mitre_car/CAR-2019-04-002.sql
@@ -1,5 +1,7 @@
 -- Generic Regsvr32
-SELECT child.pid_hash AS pid_hash
+SELECT 
+    child.pid_hash AS pid_hash,
+    COALESCE(child.first_seen, child.dayPK) as first_seen
 FROM process AS child,
     process AS parent
 WHERE

--- a/wintappy/analytics/mitre_car/CAR-2019-04-002.sql
+++ b/wintappy/analytics/mitre_car/CAR-2019-04-002.sql
@@ -1,7 +1,7 @@
 -- Generic Regsvr32
-SELECT 
+SELECT
     child.pid_hash AS pid_hash,
-    COALESCE(child.first_seen, child.dayPK) as first_seen
+    COALESCE(child.first_seen, child.daypk) AS first_seen
 FROM process AS child,
     process AS parent
 WHERE

--- a/wintappy/analytics/mitre_car/CAR-2020-11-004.sql
+++ b/wintappy/analytics/mitre_car/CAR-2020-11-004.sql
@@ -2,7 +2,7 @@
 -- Tactic: Defense Evasion; Technique: Process Injection
 SELECT
     child.pid_hash AS pid_hash,
-    child.parent_pid_hash AS parent_pid_hash
+    COALESCE(child.first_seen, child.dayPK) as first_seen
 FROM process AS child,
     process AS parent
 WHERE

--- a/wintappy/analytics/mitre_car/CAR-2020-11-004.sql
+++ b/wintappy/analytics/mitre_car/CAR-2020-11-004.sql
@@ -2,7 +2,7 @@
 -- Tactic: Defense Evasion; Technique: Process Injection
 SELECT
     child.pid_hash AS pid_hash,
-    COALESCE(child.first_seen, child.dayPK) as first_seen
+    COALESCE(child.first_seen, child.daypk) AS first_seen
 FROM process AS child,
     process AS parent
 WHERE

--- a/wintappy/analytics/mitre_car/CAR-2021-01-004.sql
+++ b/wintappy/analytics/mitre_car/CAR-2021-01-004.sql
@@ -1,7 +1,7 @@
 -- Unusual Child Process for Spoolsv.Exe or Connhost.Exe
 SELECT
     child.pid_hash AS pid_hash,
-    child.parent_pid_hash AS parent_pid_hash
+    COALESCE(child.first_seen, child.dayPK) as first_seen
 FROM process AS child,
     process AS parent
 WHERE

--- a/wintappy/analytics/mitre_car/CAR-2021-01-004.sql
+++ b/wintappy/analytics/mitre_car/CAR-2021-01-004.sql
@@ -1,7 +1,7 @@
 -- Unusual Child Process for Spoolsv.Exe or Connhost.Exe
 SELECT
     child.pid_hash AS pid_hash,
-    COALESCE(child.first_seen, child.dayPK) as first_seen
+    COALESCE(child.first_seen, child.daypk) AS first_seen
 FROM process AS child,
     process AS parent
 WHERE

--- a/wintappy/analytics/mitre_car/CAR-2021-01-006.sql
+++ b/wintappy/analytics/mitre_car/CAR-2021-01-006.sql
@@ -1,7 +1,7 @@
 -- Unusual Child Process spawned using DDE exploit
 SELECT
     child.pid_hash AS pid_hash,
-    child.parent_pid_hash AS parent_pid_hash
+    COALESCE(child.first_seen, child.dayPK) as first_seen
 FROM process AS child,
     process AS parent
 WHERE

--- a/wintappy/analytics/mitre_car/CAR-2021-01-006.sql
+++ b/wintappy/analytics/mitre_car/CAR-2021-01-006.sql
@@ -1,7 +1,7 @@
 -- Unusual Child Process spawned using DDE exploit
 SELECT
     child.pid_hash AS pid_hash,
-    COALESCE(child.first_seen, child.dayPK) as first_seen
+    COALESCE(child.first_seen, child.daypk) AS first_seen
 FROM process AS child,
     process AS parent
 WHERE

--- a/wintappy/analytics/mitre_car/CAR-2021-02-001.sql
+++ b/wintappy/analytics/mitre_car/CAR-2021-02-001.sql
@@ -3,7 +3,7 @@
 
 SELECT
     child.pid_hash AS pid_hash,
-    COALESCE(child.first_seen, child.dayPK) as first_seen
+    COALESCE(child.first_seen, child.daypk) AS first_seen
 FROM process AS child,
     process AS parent
 WHERE

--- a/wintappy/analytics/mitre_car/CAR-2021-02-001.sql
+++ b/wintappy/analytics/mitre_car/CAR-2021-02-001.sql
@@ -2,8 +2,8 @@
 -- Tactic: Persistence; Technique: Server Software Component
 
 SELECT
-    child.pid_hash,
-    parent.pid_hash
+    child.pid_hash AS pid_hash,
+    COALESCE(child.first_seen, child.dayPK) as first_seen
 FROM process AS child,
     process AS parent
 WHERE

--- a/wintappy/analytics/mitre_car/CAR-2021-02-002.sql
+++ b/wintappy/analytics/mitre_car/CAR-2021-02-002.sql
@@ -1,8 +1,8 @@
 -- Get System Elevation
 
 SELECT
-    child.pid_hash,
-    parent.pid_hash
+    child.pid_hash AS pid_hash,
+    COALESCE(child.first_seen, child.dayPK) as first_seen
 FROM process AS child,
     process AS parent
 WHERE

--- a/wintappy/analytics/mitre_car/CAR-2021-02-002.sql
+++ b/wintappy/analytics/mitre_car/CAR-2021-02-002.sql
@@ -2,7 +2,7 @@
 
 SELECT
     child.pid_hash AS pid_hash,
-    COALESCE(child.first_seen, child.dayPK) as first_seen
+    COALESCE(child.first_seen, child.daypk) AS first_seen
 FROM process AS child,
     process AS parent
 WHERE

--- a/wintappy/analytics/mitre_car/macros.sql
+++ b/wintappy/analytics/mitre_car/macros.sql
@@ -3,5 +3,5 @@
 {%- endmacro -%}
 
 {%- macro select_fallback(columns) -%}
-    {{ columns|default("pid_hash", true) }}
+    {{ columns|default("pid_hash, COALESCE(first_seen, dayPK) as first_seen", true) }}
 {%- endmacro -%}

--- a/wintappy/analytics/utils.py
+++ b/wintappy/analytics/utils.py
@@ -3,10 +3,10 @@ import os
 import shutil
 import tempfile
 from typing import Any, Dict, List, Optional
-from duckdb import CatalogException
 
 import git
 import yaml
+from duckdb import CatalogException
 from jinja2 import Environment
 from mitreattack.stix20 import MitreAttackData
 
@@ -93,13 +93,15 @@ def format_car_analytic(analytic_id: str, metadata: Dict[str, Any]) -> QueryAnal
 def run_against_day(
     daypk: int, env: Environment, db: WintapDuckDB, analytics: List[QueryAnalytic]
 ) -> None:
-    """ Runs a single or all CAR analytics against data for a single daypk."""
+    """Runs a single or all CAR analytics against data for a single daypk."""
     for analytic in analytics:
         query_str = env.get_template(analytic.analytic_template).render(
             {"search_day_pk": daypk}
         )
         try:
-            db.query(f"INSERT INTO analytics_results SELECT pid_hash, '{analytic.analytic_id}', first_seen, 'pid_hash' FROM ( {query_str} )")
+            db.query(
+                f"INSERT INTO analytics_results SELECT pid_hash, '{analytic.analytic_id}', first_seen, 'pid_hash' FROM ( {query_str} )"
+            )
         except CatalogException as err:
             # Don't include the stacktrace to keep the output succinct.
             logging.error(f"{analytic.analytic_id}: {err.args}", stack_info=False)

--- a/wintappy/database/wintap_duckdb.py
+++ b/wintappy/database/wintap_duckdb.py
@@ -48,7 +48,7 @@ class WintapDuckDB:
 
     def _is_table_or_view(self, table_name: str):
         try:
-            self.query(f'describe {table_name}')
+            self.query(f"describe {table_name}")
             logging.debug(f"table or view ({table_name}) already exists")
         except duckdb.CatalogException as err:
             logging.debug(f"table or view ({table_name}) does not exist")

--- a/wintappy/database/wintap_duckdb.py
+++ b/wintappy/database/wintap_duckdb.py
@@ -40,9 +40,20 @@ class WintapDuckDB:
 
     def _setup_tables(self) -> None:
         """Create extra tables that store analytics results"""
+        if self._is_table_or_view(ANALYTICS_RESULTS_TABLE):
+            return
         self.query(
             self._jinja_environment.get_template(CREATE_ANALYTICS_TEMPLATE).render()
         )
+
+    def _is_table_or_view(self, table_name: str):
+        try:
+            self.query(f'describe {table_name}')
+            logging.debug(f"table or view ({table_name}) already exists")
+        except duckdb.CatalogException as err:
+            logging.debug(f"table or view ({table_name}) does not exist")
+            return False
+        return True
 
     def get_tables(self) -> list:
         """


### PR DESCRIPTION
## Description

In certain cases, analytics results are already loaded via a view.  In those cases, we would run into an error trying to create the table (`CatalogException: Catalog Error: analytics_results is not an table`). This change just includes a simple check to create only if the view doesn't already exist.  Really, this is a workaround until I can dig more deeply into when we use views (read-only) and tables (when we go from raw -> rolling ?).

This PR also optimizes the inserting into the analytics_results table by moving it into a sql statement rather than going from duckdb -> python -> duckdb (just duckdb -> duckdb).  This show improvements of >10x in speed.

## Confidence

manually tested & added a couple of new unit tests 