### PR TITLE
fix imports to avoid name collision; fix relative path

### DIFF
--- a/wintappy/__init__.py
+++ b/wintappy/__init__.py
@@ -1,1 +1,1 @@
-VERSION = "0.1.2"
+VERSION = "0.1.3"

--- a/wintappy/datautils/rawutil.py
+++ b/wintappy/datautils/rawutil.py
@@ -43,7 +43,7 @@ def get_glob_paths_for_dataset(dataset, subdir="raw_sensor", include=None, looku
         if include == None or fn.startswith(include)
     ]
     # optionally add lookup directory
-    if lookups != "":
+    if lookups is not None and lookups != "":
         for lookup in os.listdir(lookups):
             event_types.append(os.path.join(lookups, lookup))
     globs = defaultdict(set)

--- a/wintappy/datautils/rawutil.py
+++ b/wintappy/datautils/rawutil.py
@@ -4,11 +4,11 @@ import re
 from collections import defaultdict
 from datetime import datetime
 from glob import glob
+from importlib.resources import files as resource_files
 
 import duckdb
 import pyarrow.parquet as pq
 from duckdb import CatalogException
-from importlib.resources import files as resource_files
 from pyarrow.lib import ArrowInvalid
 
 
@@ -270,7 +270,6 @@ def run_sql_no_args(con, sqlfile):
        Multi-line
        */
     """
-    logging.info(f"sqlfile: {sqlfile}; type: {type(sqlfile)}")
     etl_sql = loadSqlStatements(sqlfile)
     for key in etl_sql:
         logging.info(f"Processing: {key}")

--- a/wintappy/datautils/rawutil.py
+++ b/wintappy/datautils/rawutil.py
@@ -8,7 +8,7 @@ from glob import glob
 import duckdb
 import pyarrow.parquet as pq
 from duckdb import CatalogException
-from importlib_resources import files
+from importlib.resources import files as resource_files
 from pyarrow.lib import ArrowInvalid
 
 
@@ -18,7 +18,7 @@ def init_db(dataset=None, agg_level="rolling", database=":memory:", lookups=""):
     """
     con = duckdb.connect(database=database)
     # TODO fix reference to SQL scripts
-    run_sql_no_args(con, files("wintappy.datautils").joinpath("initdb.sql"))
+    run_sql_no_args(con, resource_files("wintappy.datautils").joinpath("initdb.sql"))
     if not dataset == None:
         globs = get_glob_paths_for_dataset(dataset, agg_level, lookups=lookups)
         create_views(con, globs)
@@ -270,6 +270,7 @@ def run_sql_no_args(con, sqlfile):
        Multi-line
        */
     """
+    logging.info(f"sqlfile: {sqlfile}; type: {type(sqlfile)}")
     etl_sql = loadSqlStatements(sqlfile)
     for key in etl_sql:
         logging.info(f"Processing: {key}")

--- a/wintappy/datautils/rawutil.py
+++ b/wintappy/datautils/rawutil.py
@@ -48,18 +48,20 @@ def get_glob_paths_for_dataset(dataset, subdir="raw_sensor", include=None, looku
             event_types.append(os.path.join(lookups, lookup))
     globs = defaultdict(set)
     for cur_event in event_types:
-        event_type = cur_event.split("/")[-1]
+        event_type = cur_event.split(os.sep)[-1]
         if os.path.isdir(cur_event):
             for dirpath, dirnames, filenames in os.walk(cur_event):
                 if not dirnames:
                     if dirpath == cur_event:
                         # No dir globs needed
-                        globs[event_type].add(f"{cur_event}/*.parquet")
+                        globs[event_type].add(f"{cur_event}{os.sep}*.parquet")
                     else:
                         # Remove the pre-fix, including event_type. Convert that to a glob.
                         subdir = dirpath.replace(cur_event, "")
                         glob = "/".join(["*"] * subdir.count(os.path.sep))
-                        globs[event_type].add(f"{cur_event}/{glob}/*.parquet")
+                        globs[event_type].add(
+                            os.path.join(cur_event, glob, "*.parquet")
+                        )
                         logging.debug(
                             f"{event_type} {subdir} {glob} has 0 subdirectories and {len(filenames)} files"
                         )
@@ -117,7 +119,9 @@ def get_globs_for(dataset, daypk):
     globs = {}
     for event_type, pathspec in globs_all.items():
         # Add in the daypk filter
-        pathspec = pathspec.replace("/*/", f"/dayPK={daypk}/", 1)
+        pathspec = pathspec.replace(
+            f"{os.sep}*{os.sep}", f"{os.sep}dayPK={daypk}{os.sep}", 1
+        )
         num_files = len(glob(pathspec))
         if num_files == 0:
             logging.info(f"Not found: {pathspec}  Skipping")
@@ -309,10 +313,10 @@ def write_parquet(con, datasetpath, db_objects, daypk=None):
         logging.info(f"Writing {object_name}")
         try:
             if daypk == None:
-                pathspec = f"{datasetpath}/stdview"
+                pathspec = f"{datasetpath}{os.sep}stdview"
                 filename = f"{object_name}.parquet"
             else:
-                pathspec = f"{datasetpath}/rolling/{object_name}/dayPK={daypk}"
+                pathspec = f"{datasetpath}{os.sep}rolling{os.sep}{object_name}{os.sep}dayPK={daypk}"
                 filename = f"{object_name}-{daypk}.parquet"
             if not os.path.exists(pathspec):
                 os.makedirs(pathspec)
@@ -320,7 +324,7 @@ def write_parquet(con, datasetpath, db_objects, daypk=None):
             else:
                 logging.debug(f"folder already exists: {pathspec}")
             # TODO Add test for file existence
-            sql = f"COPY {object_name} TO '{pathspec}/{filename}' (FORMAT 'parquet')"
+            sql = f"COPY {object_name} TO '{pathspec}{os.sep}{filename}' (FORMAT 'parquet')"
             con.execute(sql)
         except duckdb.IOException as e:
             logging.exception(f"Failed to write: {object_name}")

--- a/wintappy/datautils/rawutil.py
+++ b/wintappy/datautils/rawutil.py
@@ -58,7 +58,7 @@ def get_glob_paths_for_dataset(dataset, subdir="raw_sensor", include=None, looku
                     else:
                         # Remove the pre-fix, including event_type. Convert that to a glob.
                         subdir = dirpath.replace(cur_event, "")
-                        glob = "/".join(["*"] * subdir.count(os.path.sep))
+                        glob = os.sep.join(["*"] * subdir.count(os.path.sep))
                         globs[event_type].add(
                             os.path.join(cur_event, glob, "*.parquet")
                         )

--- a/wintappy/etlutils/download_from_s3.py
+++ b/wintappy/etlutils/download_from_s3.py
@@ -310,7 +310,7 @@ def main():
 
     start_date = datetime.strptime(args.start, "%Y%m%d %H")
     end_date = datetime.strptime(args.end, "%Y%m%d %H")
-
+    logging.debug(f'start_date={start_date}; end_date={end_date}')
     for event_type in event_types:
         logging.info(event_type.get("Prefix"))
         # Within an event type, iterate over date range by hour
@@ -318,6 +318,8 @@ def main():
         for single_date in hour_range(start_date, end_date):
             daypk = single_date.strftime("%Y%m%d")
             hourpk = single_date.strftime("%H")
+            logging.debug(f'daypk={daypk}; hourpk={hourpk}')
+
             prefix = (
                 f"{event_type.get('Prefix')}uploadedDPK={daypk}/uploadedHPK={hourpk}/"
             )
@@ -348,8 +350,10 @@ def main():
                 )
             else:
                 logging.debug(f"  {prefix} not in S3, skipping")
-        logging.info(f"   Downloading {len(files_md)}...")
-        download_files_threaded(args.bucket, s3, files_md)
+
+        if len(files_md) > 0:
+            logging.info(f"   Downloading {len(files_md)}...")
+            download_files_threaded(args.bucket, s3, files_md)
 
 
 if __name__ == "__main__":

--- a/wintappy/etlutils/download_from_s3.py
+++ b/wintappy/etlutils/download_from_s3.py
@@ -310,7 +310,7 @@ def main():
 
     start_date = datetime.strptime(args.start, "%Y%m%d %H")
     end_date = datetime.strptime(args.end, "%Y%m%d %H")
-    logging.debug(f'start_date={start_date}; end_date={end_date}')
+    logging.debug(f"start_date={start_date}; end_date={end_date}")
     for event_type in event_types:
         logging.info(event_type.get("Prefix"))
         # Within an event type, iterate over date range by hour
@@ -318,7 +318,7 @@ def main():
         for single_date in hour_range(start_date, end_date):
             daypk = single_date.strftime("%Y%m%d")
             hourpk = single_date.strftime("%H")
-            logging.debug(f'daypk={daypk}; hourpk={hourpk}')
+            logging.debug(f"daypk={daypk}; hourpk={hourpk}")
 
             prefix = (
                 f"{event_type.get('Prefix')}uploadedDPK={daypk}/uploadedHPK={hourpk}/"

--- a/wintappy/etlutils/rawtorolling.py
+++ b/wintappy/etlutils/rawtorolling.py
@@ -2,7 +2,6 @@ import argparse
 import logging
 import sys
 from datetime import datetime
-
 from importlib.resources import files as resource_files
 
 from wintappy.datautils import rawutil as ru

--- a/wintappy/etlutils/rawtorolling.py
+++ b/wintappy/etlutils/rawtorolling.py
@@ -1,10 +1,9 @@
 import argparse
 import logging
 import sys
-from datetime import datetime, timedelta
+from datetime import datetime
 
-from importlib_resources import files
-from jinjasql import JinjaSql
+from importlib.resources import files as resource_files
 
 from wintappy.datautils import rawutil as ru
 from wintappy.etlutils.utils import daterange
@@ -18,7 +17,7 @@ def process_range(cur_dataset, start_date, end_date):
         # No need to pass dayPK as the globs already include it.
         ru.create_raw_views(con, globs)
         ru.run_sql_no_args(
-            con, files("wintappy.datautils").joinpath("rawtostdview.sql")
+            con, resource_files("wintappy.datautils").joinpath("rawtostdview.sql")
         )
         ru.write_parquet(
             con, cur_dataset, ru.get_db_objects(con, exclude=["tmp"]), daypk

--- a/wintappy/etlutils/rawtostdview.py
+++ b/wintappy/etlutils/rawtostdview.py
@@ -1,7 +1,6 @@
 import argparse
 import logging
 import sys
-
 from importlib.resources import resource_files
 
 from wintappy.datautils import rawutil as ru
@@ -38,7 +37,9 @@ def main():
     con = ru.init_db()
     globs = ru.get_glob_paths_for_dataset(cur_dataset, subdir="rolling", include="raw_")
     ru.create_raw_views(con, globs, args.start, args.end)
-    ru.run_sql_no_args(con, resource_files("wintappy.datautils").joinpath("rawtostdview.sql"))
+    ru.run_sql_no_args(
+        con, resource_files("wintappy.datautils").joinpath("rawtostdview.sql")
+    )
     ru.write_parquet(con, cur_dataset, ru.get_db_objects(con, exclude=["raw_", "tmp"]))
 
 

--- a/wintappy/etlutils/rawtostdview.py
+++ b/wintappy/etlutils/rawtostdview.py
@@ -1,7 +1,8 @@
 import argparse
 import logging
 import sys
-from datetime import datetime
+
+from importlib.resources import resource_files
 
 from wintappy.datautils import rawutil as ru
 
@@ -37,7 +38,7 @@ def main():
     con = ru.init_db()
     globs = ru.get_glob_paths_for_dataset(cur_dataset, subdir="rolling", include="raw_")
     ru.create_raw_views(con, globs, args.start, args.end)
-    ru.run_sql_no_args(con, "./rawtostdview.sql")
+    ru.run_sql_no_args(con, resource_files("wintappy.datautils").joinpath("rawtostdview.sql"))
     ru.write_parquet(con, cur_dataset, ru.get_db_objects(con, exclude=["raw_", "tmp"]))
 
 

--- a/wintappy/etlutils/rawtostdview.py
+++ b/wintappy/etlutils/rawtostdview.py
@@ -1,7 +1,7 @@
 import argparse
 import logging
 import sys
-from importlib.resources import resource_files
+from importlib.resources import files as resource_files
 
 from wintappy.datautils import rawutil as ru
 


### PR DESCRIPTION
## Description

A few minor fixes / changes:

- Fixing import in `rawtorolling` util
- FIx name collision between `files` in sql and function name
- Add check before running commands (ran into some weirdness there when there weren't any)

## Testing 
On both windows and mac:
- download_from_s3
- rawtorolling
- rawtostdview