### PR TITLE
Grantj fix groupbys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,5 +65,18 @@ wintappy/examples/*.db
 .mypy_cache/
 .pytest_cache/
 
+# Emacs files
+*~
+\#*\#
+/.emacs.desktop
+/.emacs.desktop.lock
+*.elc
+auto-save-list
+tramp
+.\#*
+
 # Ignore dynaconf secret files
 .secrets.*
+
+# Local config file
+wintappy_settings.toml

--- a/wintappy/analytics/utils.py
+++ b/wintappy/analytics/utils.py
@@ -106,6 +106,7 @@ def load_single(analytic_id: str) -> Optional[QueryAnalytic]:
 def load_all(env: Environment) -> Dict[str, QueryAnalytic]:
     analytics: Dict[str, QueryAnalytic] = {}
     metadata = load_car_analtyic_metadata()
+    logging.debug(f"templates({len(env.list_templates())}): {env.list_templates()}")
     for template in env.list_templates():
         if template.endswith(".sql"):
             analytic_id = template.removesuffix(".sql")
@@ -118,12 +119,12 @@ def load_car_analtyic_metadata() -> Dict[str, Dict[str, Any]]:
     # list to hold analytic data
     analytics = {}
     # create temporary dir
-    tmp_dir = f"{tempfile.mkdtemp()}{os.sep}{ANALYTICS_DIR}"
+    tmp_dir = f"{tempfile.mkdtemp()}"
     # clone car data into the temporary dir
     fs = fsspec.filesystem("github", org=CAR_REPO_OWNER, repo=CAR_REPO_NAME)
     get_files(fs, tmp_dir, fs.ls(ANALYTICS_DIR))
     # load yaml files into list of dictionaries
-    for f in os.scandir(tmp_dir):
+    for f in os.scandir(f"{tmp_dir}{os.sep}{ANALYTICS_DIR}"):
         if f.is_file() and f.name.endswith("yaml"):
             with open(f.path, "r", encoding="utf-8") as single:
                 try:

--- a/wintappy/datautils/rawtostdview.sql
+++ b/wintappy/datautils/rawtostdview.sql
@@ -47,7 +47,7 @@ SELECT
  count(DISTINCT collectors) num_collectors,
  count(*) num_rows
 FROM raw_host
-GROUP BY 1
+GROUP BY ALL
 ;
 
 
@@ -131,7 +131,7 @@ SELECT p.pidhash pid_hash, -- osfamily will eventually come back as a partition 
        to_timestamp_micros(win32_to_epoch(max(p.eventtime))) last_seen,
        count(*) num_start_events
 FROM raw_process p
-GROUP BY p.pidhash
+GROUP BY ALL
 ;
 
 --== Update process_path
@@ -176,7 +176,7 @@ LEFT OUTER JOIN
           max(exitcode) exit_code,
           count(*) num_process_stop
    FROM raw_process_stop
-   GROUP BY pidhash) s ON p.pid_hash = s.pidhash
+   GROUP BY ALL) s ON p.pid_hash = s.pidhash
 ;
 
 
@@ -400,9 +400,7 @@ SELECT os_family,
  avg(total_events) avg_packets,
  sum(sq_size) sq_size
 FROM process_net_conn
-GROUP BY 1,
-         2,
-         3
+GROUP BY ALL
 ;
 
 -- Summarize file activity to PID_HASH+FILE_HASH
@@ -538,10 +536,7 @@ AS file_first_seen,
        NULL
 AS file_last_seen
 FROM process_image_load
-GROUP BY 1,
-         2,
-         3,
-         4
+GROUP BY ALL
 UNION
 SELECT file_id,
        hostname,
@@ -563,9 +558,7 @@ AS dll_last_seen,
        min(first_seen) file_first_seen,
        max(last_seen) file_last_seen
 FROM process_file
-GROUP BY 1,
-         2,
-         3
+GROUP BY ALL
 ;
 
 
@@ -584,9 +577,7 @@ SELECT file_id,
        min(file_first_seen) file_first_seen,
        max(file_last_seen) file_last_seen
 FROM files_tmp_v1
-GROUP BY 1,
-         2,
-         3
+GROUP BY ALL
 ;
 
 -- Create a set of files using just the filename.
@@ -599,7 +590,7 @@ SELECT filename,
        sum(dll_num_rows) dll_num_rows,
        sum(file_num_rows) file_num_rows
 FROM files
-GROUP BY 1
+GROUP BY ALL
 ;
 
 -- Generate Process Trees. There *should* be 1 graph per unique NTOSKRNL.EXE process.

--- a/wintappy/datautils/rawutil.py
+++ b/wintappy/datautils/rawutil.py
@@ -322,7 +322,7 @@ def get_db_objects(con, exclude=None):
     return tables
 
 
-def write_parquet(con, datasetpath, db_objects, daypk=None,agg_level="stdview"):
+def write_parquet(con, datasetpath, db_objects, daypk=None, agg_level="stdview"):
     """
     Write tables/views from duckdb instance to parquet.
     If daypk is provided, write to corresponding path in rolling.

--- a/wintappy/datautils/rawutil.py
+++ b/wintappy/datautils/rawutil.py
@@ -191,7 +191,7 @@ def generate_view_sql(event_map, start=None, end=None):
     # View Template
     stmts = []
     for event_type, pathspec in event_map.items():
-        if "raw_" in event_type and '/raw_sensor/' in pathspec:
+        if "raw_" in event_type and "/raw_sensor/" in pathspec:
             # Raw files *may* have differing schemas, so enable union'ing of all schemas.
             # FIX in Wintap(?): Found that exact dups are in the raw tables, so remove them here using the GROUP BY ALL.
             # Only implement duplicate fix on 'raw_sensor' path. RAW tables in 'rolling' are already fixed.

--- a/wintappy/datautils/rawutil.py
+++ b/wintappy/datautils/rawutil.py
@@ -191,9 +191,10 @@ def generate_view_sql(event_map, start=None, end=None):
     # View Template
     stmts = []
     for event_type, pathspec in event_map.items():
-        # Hack! Found that dups are in the raw tables, so remove them here using the GROUP BY ALL.
-        if "raw_" in event_type:
+        if "raw_" in event_type and '/raw_sensor/' in pathspec:
             # Raw files *may* have differing schemas, so enable union'ing of all schemas.
+            # FIX in Wintap(?): Found that exact dups are in the raw tables, so remove them here using the GROUP BY ALL.
+            # Only implement duplicate fix on 'raw_sensor' path. RAW tables in 'rolling' are already fixed.
             view_sql = f"""
             create or replace view {event_type} as
             select *, count(*) num_dups from parquet_scan('{pathspec}',hive_partitioning=1,union_by_name=true) group by all

--- a/wintappy/datautils/stdview_duckdb.py
+++ b/wintappy/datautils/stdview_duckdb.py
@@ -198,7 +198,7 @@ def fetch_summary_data(con):
     return eventDF
 
 
-def display_event_chart(eventDF,width=1200,height=600):
+def display_event_chart(eventDF, width=1200, height=600):
     # Set jupyter options
     pd.set_option("display.max_columns", None)
     pd.set_option("display.max_colwidth", None)
@@ -207,7 +207,7 @@ def display_event_chart(eventDF,width=1200,height=600):
     alt.data_transformers.disable_max_rows()
 
     # Create a compound key for the Y. Can't seem to specify it in the altair syntax
-    allEvents = eventDF.assign(Hostname_Event=lambda x: x.Hostname+": "+x.Event)
+    allEvents = eventDF.assign(Hostname_Event=lambda x: x.Hostname + ": " + x.Event)
 
     eventsChart = (
         alt.Chart(allEvents)

--- a/wintappy/etlutils/download_from_s3.py
+++ b/wintappy/etlutils/download_from_s3.py
@@ -222,6 +222,16 @@ def parse_s3_metadata(files, local_path, uploadedDPK, uploadedHPK, event_type):
         new_event_type = event_type
     else:
         new_event_type = "raw_" + event_type
+
+    # Modify some event names to what SQL expects
+    # To Do: Fix this in Wintap
+    if new_event_type=='raw_file':
+        new_event_type='raw_process_file'
+    if new_event_type=='raw_registry':
+        new_event_type='raw_process_registry'
+    if new_event_type=='raw_processstop':
+        new_event_type='raw_process_stop'
+         
     files_metadata = []
     back_dated = {}
     for file in files:
@@ -330,10 +340,8 @@ def main(argv=None) -> None:
             hourpk = single_date.strftime("%H")
             logging.debug(f"daypk={daypk}; hourpk={hourpk}")
 
-            # Note: 'Prefix' has a trailing slash already.
-            prefix = (
-                f"{event_type.get('Prefix')}uploadedDPK={daypk}/uploadedHPK={hourpk}/"
-            )
+            # Note: 'Prefix' includes a trailing slash.
+            prefix = f"{event_type.get('Prefix')}uploadedDPK={daypk}/uploadedHPK={hourpk}/"
 
             # Optimization: many event types are sparsely populated, so enumerate the dayPK/hourPK structure, then just get files from the ones that exist.
             files_tmp, existing_S3_paths = list_folders(

--- a/wintappy/etlutils/download_from_s3.py
+++ b/wintappy/etlutils/download_from_s3.py
@@ -225,13 +225,13 @@ def parse_s3_metadata(files, local_path, uploadedDPK, uploadedHPK, event_type):
 
     # Modify some event names to what SQL expects
     # To Do: Fix this in Wintap
-    if new_event_type=='raw_file':
-        new_event_type='raw_process_file'
-    if new_event_type=='raw_registry':
-        new_event_type='raw_process_registry'
-    if new_event_type=='raw_processstop':
-        new_event_type='raw_process_stop'
-         
+    if new_event_type == "raw_file":
+        new_event_type = "raw_process_file"
+    if new_event_type == "raw_registry":
+        new_event_type = "raw_process_registry"
+    if new_event_type == "raw_processstop":
+        new_event_type = "raw_process_stop"
+
     files_metadata = []
     back_dated = {}
     for file in files:
@@ -341,7 +341,9 @@ def main(argv=None) -> None:
             logging.debug(f"daypk={daypk}; hourpk={hourpk}")
 
             # Note: 'Prefix' includes a trailing slash.
-            prefix = f"{event_type.get('Prefix')}uploadedDPK={daypk}/uploadedHPK={hourpk}/"
+            prefix = (
+                f"{event_type.get('Prefix')}uploadedDPK={daypk}/uploadedHPK={hourpk}/"
+            )
 
             # Optimization: many event types are sparsely populated, so enumerate the dayPK/hourPK structure, then just get files from the ones that exist.
             files_tmp, existing_S3_paths = list_folders(

--- a/wintappy/etlutils/rawtostdview.py
+++ b/wintappy/etlutils/rawtostdview.py
@@ -44,7 +44,12 @@ def main(argv=None):
     ru.run_sql_no_args(
         con, resource_files("wintappy.datautils").joinpath("rawtostdview.sql")
     )
-    ru.write_parquet(con, cur_dataset, ru.get_db_objects(con, exclude=["raw_", "tmp"]), agg_level=f"stdview-{args.START}-{args.END}")
+    ru.write_parquet(
+        con,
+        cur_dataset,
+        ru.get_db_objects(con, exclude=["raw_", "tmp"]),
+        agg_level=f"stdview-{args.START}-{args.END}",
+    )
 
 
 if __name__ == "__main__":

--- a/wintappy/etlutils/rawtostdview.py
+++ b/wintappy/etlutils/rawtostdview.py
@@ -40,11 +40,11 @@ def main(argv=None):
 
     con = ru.init_db()
     globs = ru.get_glob_paths_for_dataset(cur_dataset, subdir="rolling", include="raw_")
-    ru.create_raw_views(con, globs)
+    ru.create_raw_views(con, globs, args.START, args.END)
     ru.run_sql_no_args(
         con, resource_files("wintappy.datautils").joinpath("rawtostdview.sql")
     )
-    ru.write_parquet(con, cur_dataset, ru.get_db_objects(con, exclude=["raw_", "tmp"]))
+    ru.write_parquet(con, cur_dataset, ru.get_db_objects(con, exclude=["raw_", "tmp"]), agg_level=f"stdview-{args.START}-{args.END}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Misc cleanup and fixes

- For consistency, convert all GROUP BY's to use GROUP BY ALL
- Fix event_name strings as they had changed over time
- Remove duplicate rows only in the transition from the raw_sensor path merged raw_{files} in rolling
- Clean up the host chart by forcing all hostnames to uppercase
- Fix rawtostdview to support start/end dates