### PR TITLE
Grantj fix process path

### DIFF
--- a/wintappy/datautils/process_path.sql
+++ b/wintappy/datautils/process_path.sql
@@ -1,7 +1,7 @@
 -- Considering now that the term "tree" is a misnomer: these are really "paths to root"
 -- Had the concept of having a "tree_id", but what would that actually be? 
 
-create table process_paths
+create table process_path
 as
 select * from (
     with recursive cte_process_tree (
@@ -54,11 +54,13 @@ select * from (
             p.pid_hash = pt.parent_pid_hash
             and pt.parent_pid_hash != pt.pid_hash
             and not list_contains(pt.ptree_list, p.pid_hash)
+            -- optimization?
+            and p.hostname=pt.hostname
     )
-
     select
         *,
         max(level) over (partition by pid_hash) as max_level
     from cte_process_tree
 )
-where max_level = level;
+where max_level = level
+;

--- a/wintappy/datautils/rawtostdview.sql
+++ b/wintappy/datautils/rawtostdview.sql
@@ -437,7 +437,7 @@ SELECT
     pidhash pid_hash,
     processname process_name,
     md5(concat_ws('||', computername, lower(filename))) file_id,
-    mode(md5) file_md5,
+    first(md5) file_md5,
     count(DISTINCT md5) num_file_md5,
     lower(filename) filename,
     max(buildtime) build_time,

--- a/wintappy/etlutils/runone.py
+++ b/wintappy/etlutils/runone.py
@@ -9,14 +9,14 @@ from wintappy.etlutils.utils import configure_basic_logging
 
 save_db_objects = []
 
+
 def get_hosts(con):
-    rows=con.execute("select distinct hostname from process order by all")
+    rows = con.execute("select distinct hostname from process order by all")
     return rows
 
+
 def run_one(con, script):
-    ru.run_sql_no_args(
-        con, resource_files("wintappy.datautils").joinpath(script)
-    )
+    ru.run_sql_no_args(con, resource_files("wintappy.datautils").joinpath(script))
 
 
 def main(argv=None):
@@ -37,7 +37,6 @@ def main(argv=None):
     su.create_process_view(con, args.DATASET, args.AGGLEVEL)
 
     logging.info(f"Creating Process Path")
-
 
     run_one(con, "process_path.sql")
     save_db_objects.extend(["process_path"])

--- a/wintappy/etlutils/runone.py
+++ b/wintappy/etlutils/runone.py
@@ -1,0 +1,57 @@
+import argparse
+import logging
+from importlib.resources import files as resource_files
+
+from wintappy.config import get_configs
+from wintappy.datautils import rawutil as ru
+from wintappy.datautils import summary_util as su
+from wintappy.etlutils.utils import configure_basic_logging
+
+save_db_objects = []
+
+def get_hosts(con):
+    rows=con.execute("select distinct hostname from process order by all")
+    return rows
+
+def run_one(con, script):
+    ru.run_sql_no_args(
+        con, resource_files("wintappy.datautils").joinpath(script)
+    )
+
+
+def main(argv=None):
+    configure_basic_logging()
+    parser = argparse.ArgumentParser(
+        prog="runone.py",
+        description="Run one script over dataset",
+    )
+    parser.add_argument("-s", "--start", help="Start date (YYYYMMDD)")
+    parser.add_argument("-e", "--end", help="End date (YYYYMMDD)")
+
+    args = get_configs(parser, argv)
+
+    # Use a persistent db may allow this to finish
+    con = ru.init_db(database="faster-than-memory-maybe.db")
+    # Create a view for the PROCESS table.
+    logging.info(f"Creating PROCESS view: {args.DATASET} -> {args.AGGLEVEL}")
+    su.create_process_view(con, args.DATASET, args.AGGLEVEL)
+
+    logging.info(f"Creating Process Path")
+
+
+    run_one(con, "process_path.sql")
+    save_db_objects.extend(["process_path"])
+
+    logging.debug(con.execute("show tables").fetchall())
+    ru.write_parquet(
+        con,
+        args.DATASET,
+        save_db_objects,
+        agg_level=f"{args.AGGLEVEL}",
+    )
+
+    logging.info("Complete")
+
+
+if __name__ == "__main__":
+    main(argv=None)


### PR DESCRIPTION
Fixed white space errors in PROCESS_PATH SQL that was causing our parser to misread the SQL and not execute it.

Changed the use of the MODE function back to FIRST as MODE requires state and introduces a considerable performance issue with larger data sets.

Introducing a new script to run 1 SQL processing script. This needs more work to generalize, with the idea being that we can use it to run/re-run subsets of the overall pipeline.