### PR TITLE
Data processing bug fixes

### DIFF
--- a/wintappy/datautils/process_path.sql
+++ b/wintappy/datautils/process_path.sql
@@ -57,8 +57,8 @@ select * from (
             p.pid_hash = pt.parent_pid_hash
             and pt.parent_pid_hash != pt.pid_hash
             and not list_contains(pt.ptree_list, p.pid_hash)
-            -- optimization?
-            and p.agent_id=pt.agent_id
+            -- optimization? Do not use agent_id because its null for older data, like ACME.
+            and p.hostname=pt.hostname
     )
     select
         *,

--- a/wintappy/datautils/process_path.sql
+++ b/wintappy/datautils/process_path.sql
@@ -57,7 +57,10 @@ select * from (
             p.pid_hash = pt.parent_pid_hash
             and pt.parent_pid_hash != pt.pid_hash
             and not list_contains(pt.ptree_list, p.pid_hash)
-            -- optimization? Do not use agent_id because its null for older data, like ACME.
+            -- This *may* be an optimization. The intent is to help the optimizer reduce scope.
+            -- Note: Do not use agent_id because its null for older data, like ACME.
+            -- For cases like malware sandbox where all VM executions use the same hostname, PID_HASH will
+            -- still keep executions isolated as they use agent_id in their pid_hash.
             and p.hostname=pt.hostname
     )
     select

--- a/wintappy/datautils/rawtostdview.sql
+++ b/wintappy/datautils/rawtostdview.sql
@@ -193,7 +193,7 @@ WHERE
 -- Move to Wintap
 
 UPDATE process
-SET file_id = md5(concat_ws('||', hostname, lower(filename)))
+SET file_id = md5(concat_ws('||', agent_id, lower(filename)))
 WHERE filename IS NOT NULL
 ;
 
@@ -391,7 +391,7 @@ SELECT
     hostname,
     pidhash pid_hash, -- generate FileID
     processname process_name,
-    md5(concat_ws('||', hostname, lower(file_path))) file_id,
+    md5(concat_ws('||', agentid, lower(file_path))) file_id,
     file_hash file_hash,
     file_path filename,
     activitytype activity_type,

--- a/wintappy/datautils/rawtostdview.sql
+++ b/wintappy/datautils/rawtostdview.sql
@@ -193,7 +193,7 @@ WHERE
 -- Move to Wintap
 
 UPDATE process
-SET file_id = md5(concat_ws('||', agent_id, filename))
+SET file_id = md5(concat_ws('||', hostname, lower(filename)))
 WHERE filename IS NOT NULL
 ;
 
@@ -391,7 +391,7 @@ SELECT
     hostname,
     pidhash pid_hash, -- generate FileID
     processname process_name,
-    md5(concat_ws('||', agentid, file_path)) file_id,
+    md5(concat_ws('||', hostname, lower(file_path))) file_id,
     file_hash file_hash,
     file_path filename,
     activitytype activity_type,

--- a/wintappy/datautils/summary_util.py
+++ b/wintappy/datautils/summary_util.py
@@ -12,6 +12,7 @@ def create_lolbas_view(con, dataset):
         SELECT * FROM read_csv_auto('{dataset}/../lookups/benignware/lolbas.csv',header=true,normalize_names=1)
     """
     con.execute(sql)
+    return True
 
 
 def create_mitre_labels_view(con, dataset, agglevel="rolling") -> bool:
@@ -36,6 +37,7 @@ def create_networkx_view(con, dataset):
     # Set max JSON size to 64MB
     sql = f"create or replace view labels_networkx as select * from read_json_auto('{dataset}/labels/networkx/*.json', filename=true, maximum_object_size=67108864)"
     con.execute(sql)
+    return True
 
 
 def create_process_view(con, dataset, agglevel="rolling"):

--- a/wintappy/etlutils/ubersummary.py
+++ b/wintappy/etlutils/ubersummary.py
@@ -21,6 +21,7 @@ def label_summary(con, dataset):
                 "labels_networkx",
             ]
         )
+        logging.debug("Found labels")
     logging.debug(con.execute("show tables").fetchall())
     for sqlfile in ["label_summary.sql"]:
         ru.run_sql_no_args(con, resource_files("wintappy.datautils").joinpath(sqlfile))
@@ -98,6 +99,7 @@ def main(argv=None):
     uber_summary(con)
 
     logging.debug(con.execute("show tables").fetchall())
+    logging.debug(f"Objects to save: {save_db_objects}")
     ru.write_parquet(
         con,
         args.DATASET,


### PR DESCRIPTION
In working through curating an example data set, several bugs were found that needed to be addressed:

* Fix process_path to work with older datasets with no agent_id
* Found some label tables were missing in the dbhelper duckdb instance
* File_ID generation was inconsistent, leading to cases where data didn't join correctly
* Implemented a new feature of dbhelper to create a portable version, which is a duckdb with all data included as native rather than views to parquet. Motivation is to provide a simpler means for sharing, posting, transferring smaller datasets
 